### PR TITLE
Fixes for Linux and Docker Versions (NOT tested on windows and mac)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@ RUN apt-get update \
  && apt-get install -yq --no-install-recommends git build-essential ca-certificates \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/ggerganov/llama.cpp /tmp/llama.cpp
-RUN cd /tmp/llama.cpp && make -j
+ENV LD_LIBRARY_PATH=/usr/local/lib64:$LD_LIBRARY_PATH
 
-FROM node:19.8 as alpaca-electron-builder
+RUN git clone https://github.com/ggerganov/llama.cpp /tmp/llama.cpp
+RUN cd /tmp/llama.cpp && git checkout master-87a6f84 && make -j
+
+FROM node:20.0-bullseye as alpaca-electron-builder
 
 USER root
 
@@ -44,4 +46,4 @@ RUN mkdir -p /home/debian/.config && chown debian:debian /home/debian/.config
 
 USER 1000
 ENTRYPOINT [ "tini", "--" ]
-CMD [ "bash", "-c", "/alpaca-electron/Alpaca\\ Electron --no-sandbox & sleep 5 && while [[ $(ps | grep 'Alpaca\\ Electron' | wc -l) -gt 0 ]]; do sleep 5; done" ]
+CMD [ "bash", "-c", "/alpaca-electron/Alpaca\\ Electron --no-sandbox --disable-gpu & sleep 5 && while [[ $(ps | grep 'Alpaca\\ Electron' | wc -l) -gt 0 ]]; do sleep 5; done" ]

--- a/index.js
+++ b/index.js
@@ -215,14 +215,11 @@ function restart() {
 	win.webContents.send("result", {
 		data: "\n\n<end>"
 	});
-  console.log("terminating shell")
   if (runningShell) runningShell.kill();
-  console.log("unset variables")
 	runningShell = undefined;
 	currentPrompt = undefined;
 	alpacaReady = false;
 	alpacaHalfReady = false;
-  console.log("initChat")
 	initChat();
 }
 

--- a/index.js
+++ b/index.js
@@ -101,7 +101,27 @@ ipcMain.on("os", () => {
 
 // SET-UP
 const Store = require("electron-store");
-const store = new Store();
+const schema = {
+	params: {
+		default: {
+      repeat_last_n: "64",
+      repeat_penalty: "1.3",
+      top_k: "40",
+      top_p: "0.9",
+      temp: "0.8",
+      seed: "-1",
+      webAccess: false,
+      websearch_amount: '5'
+    }
+	},
+  modelPath: {
+    default: "undefined"
+  },
+  supportsAVX2: {
+    default: "undefined"
+  }
+};
+const store = new Store({schema});
 const fs = require("fs");
 var modelPath = store.get("modelPath");
 
@@ -195,11 +215,14 @@ function restart() {
 	win.webContents.send("result", {
 		data: "\n\n<end>"
 	});
-	runningShell.kill();
+  console.log("terminating shell")
+  if (runningShell) runningShell.kill();
+  console.log("unset variables")
 	runningShell = undefined;
 	currentPrompt = undefined;
 	alpacaReady = false;
 	alpacaHalfReady = false;
+  console.log("initChat")
 	initChat();
 }
 
@@ -214,7 +237,7 @@ function initChat() {
 		res = stripAnsi(res);
 		console.log(`//> ${res}`);
 		if ((res.includes("llama_model_load: invalid model file") || res.includes("llama_model_load: failed to open") || res.includes("llama_init_from_file: failed to load model")) && res.includes("main: error: failed to load model")) {
-			runningShell.kill();
+			if (runningShell) runningShell.kill();
 			win.webContents.send("modelPathValid", { data: false });
 		} else if (res.includes("\n>") && !alpacaReady) {
 			alpacaHalfReady = true;
@@ -228,7 +251,7 @@ function initChat() {
 			console.log("checking avx compat");
 		} else if (res.match(/PS [A-Z]:.*>/) && checkAVX) {
 			console.log("avx2 incompatible, retrying with avx1");
-			runningShell.kill();
+			if (runningShell) runningShell.kill();
 			runningShell = undefined;
 			currentPrompt = undefined;
 			alpacaReady = false;
@@ -251,14 +274,7 @@ function initChat() {
 		}
 	});
 
-	const params = store.get("params") || {
-		repeat_last_n: "64",
-		repeat_penalty: "1.3",
-		top_k: "40",
-		top_p: "0.9",
-		temp: "0.8",
-		seed: "-1"
-	};
+	const params = store.get("params");
 	const chatArgs = `--interactive-first -i -ins -r "User:" -f "${path.resolve(__dirname, "bin", "prompts", "alpaca.txt")}"`;
 	const paramArgs = `-m "${modelPath}" -n -1 --ctx_size 2048 --temp ${params.temp} --top_k ${params.top_k} --top_p ${params.top_p} --threads ${threads} --batch_size ${threads} --repeat_last_n ${params.repeat_last_n} --repeat_penalty ${params.repeat_penalty} --seed ${params.seed}`;
 	if (platform == "win32") {
@@ -286,7 +302,7 @@ ipcMain.on("message", async (_event, { data }) => {
 });
 ipcMain.on("stopGeneration", () => {
 	if (runningShell) {
-		runningShell.kill();
+		if (runningShell) runningShell.kill();
 		runningShell = undefined;
 		currentPrompt = undefined;
 		alpacaReady = false;


### PR DESCRIPTION
On a clean startup with no config file the model selection didn't result in a working state, but in a state with no `runningShell` set. This was caused by `runningShell.kill()` blocking the `restart()` function. This is fixed by checking for a set `runningShell` before calling `kill`.

On a clean startup with no config file the `params` is unset and thus the call returns a undefined value. This resulted in a not working state until the settings got set by using the settings tab and is fixed by using a schema with default values for the electron store. 

Also updated the Dockerfile (see commit message).

The changes are only tested on linux and docker on linux. Please test on windows and mac before merging. 