### PR TITLE
Added Arm support for Raspberry Pi compatibility for Alpaca Electron.…

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,11 @@
 		"rebuild": ".\\node_modules\\.bin\\electron-rebuild",
 		"rebuild-linux": "npx --openssl_fips='' electron-rebuild",
 		"make-linux-x64": "npx electron-packager . --overwrite --platform=linux --arch=x64 --icon=icon/png/128x128.png --prune=true --electron-version=13.6.9 --app-copyright='Pi' --out=./release-builds  --version-string.CompanyName=Pi",
-		"pack-linux-x64": "tar czf release-builds/Alpaca-Electron-linux-x64-vx.x.x.tar.gz \"release-builds/Alpaca Electron-linux-x64\"",
-		"linux-x64": "npm run rebuild-linux && npm run make-linux-x64 && npm run pack-linux-x64"
+		"pack-linux-x64": "tar czf release-builds/Alpaca-Electron-linux-x64-1.0.6.tar.gz \"release-builds/Alpaca Electron-linux-x64\"",
+		"linux-x64": "npm run rebuild-linux && npm run make-linux-x64 && npm run pack-linux-x64",
+        "make-linux-arm64": "npx electron-packager . --overwrite --platform=linux --arch=arm64 --icon=icon/png/128x128.png --prune=true --electron-version=13.6.9 --app-copyright='Pi' --out=./release-builds  --version-string.CompanyName=Pi",
+        "pack-linux-arm64": "tar czf release-builds/Alpaca-Electron-linux-arm64-1.0.6.tar.gz \"release-builds/Alpaca Electron-linux-arm64\"",
+        "linux-arm64": "npm run rebuild-linux && npm run make-linux-arm64 && npm run pack-linux-arm64"
 	},
 	"dependencies": {
 		"@electron/remote": "^2.0.9",


### PR DESCRIPTION
… After you add the arm scripts just run npm run linux-arm64 if your running arm 64